### PR TITLE
Fix semver dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ name = "strfile"
 path = "lib.rs"
 
 [dependencies]
-byteorder = "0.3.1.3"
+byteorder = "0.3.13"


### PR DESCRIPTION
This syntax is not actually valid, but older `semver` packages parsed it. It resolved it as though you'd typed this, see below:

``` bash
$ cargo build
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling byteorder v0.3.13
   Compiling strfile v0.1.2 (file:///blah/blah)
    Finished debug [unoptimized + debuginfo] target(s) in 0.32 secs
```
